### PR TITLE
Restructure tax

### DIFF
--- a/src/fplan/fplan.py
+++ b/src/fplan/fplan.py
@@ -71,7 +71,6 @@ class Data:
         self.taxrates = [[x,y/100.0] for (x,y) in tmp_taxrates]
         cutoffs = [x[0] for x in self.taxrates][1:] + [float('inf')]
         self.taxtable = list(map(lambda x, y: [x[1], x[0], y], self.taxrates, cutoffs))
-#        print(self.taxtable)
 
         self.state_tax = self.state_tax / 100.0
         self.state_cg_tax = self.state_cg_tax / 100.0
@@ -221,7 +220,6 @@ def solve(args):
         for idx, (rate, low, high) in enumerate(S.taxtable[0:-1]):
             # limit how much can be put in each tax bracket
             row = [0] * nvars
-            row[0] * nvars
             row[n0+vper*year+5+idx] = 1
             A += [row]
             b += [(high - low) * i_mul]
@@ -397,9 +395,6 @@ def solve(args):
         print(res)
         exit(1)
 
-#    for i in range(vper):
-#        print(res.x[n0+i], end="\t")
-#    print()
     return res.x
 
 def print_ascii(res):

--- a/src/fplan/fplan.py
+++ b/src/fplan/fplan.py
@@ -211,6 +211,7 @@ def solve(args):
         else:
             basis = 1
 
+
         # limit how much can be considered part of the standard deduction
         row = [0] * nvars
         row[n0+vper*year+4] = 1
@@ -472,7 +473,7 @@ def print_ascii(res):
         # aftertax basis
         if S.aftertax['basis'] > 0:
             basis = 1 - (S.aftertax['basis'] /
-                         (S.aftertax['bal']*S.r_rate**year))
+                         (S.aftertax['bal']*S.r_rate**(year+S.workyr)))
         else:
             basis = 1
         tax += fsavings * basis * (cg_tax + S.state_cg_tax)


### PR DESCRIPTION
This is a restructure of how the tax constraints are built.  It computes the same yearly spend as the original version for every file in the "examples" subdirectory.

I think that this approach will allow us to compute some things that I had no idea how to compute before (like capital gains brackets and the tax-ability of social security).

It does come at a cost of a lot more columns and being not as elegant as the previous way of doing things.  Do you think this is a reasonable think to do?